### PR TITLE
Typings and direct element pass

### DIFF
--- a/src/brace-diff.d.ts
+++ b/src/brace-diff.d.ts
@@ -84,6 +84,10 @@ declare module AceDiff {
          * Options for configuring miscellaneous CSS classes used.
          */
         classes?: AceDiffClassOptions
+        /**
+         * Instead of gutterID, the document element itself can be passed.
+         */
+        gutterEl?: HTMLElement
     }
 
     interface AceDiffEditorOptions {
@@ -119,10 +123,6 @@ declare module AceDiff {
          * The ID of the gutter element.
          */
         gutterID?: string
-        /**
-         * Instead of gutterID, the document element itself can be passed.
-         */
-        gutterEl?: HTMLElement
         /**
          * The class for a diff line on either editor.
          */

--- a/src/brace-diff.js
+++ b/src/brace-diff.js
@@ -63,6 +63,14 @@ function AceDiff(options)
         connectorYOffset: 0
     }, options);
 
+    if(this.options.left.id && typeof this.options.left.id === "object") {
+        this.options.left.element = this.options.left.id;
+    }
+
+    if(this.options.right.id && typeof this.options.right.id === "object") {
+        this.options.right.element = this.options.right.id;
+    }
+
     // instantiate the editors in an internal data structure that will store a little info about the diffs and
     // editor content
     this.editors = {
@@ -771,7 +779,6 @@ function createCopyContainers(acediff)
     acediff.copyRightContainer.setAttribute('class', acediff.options.classes.copyRightContainer);
     acediff.copyLeftContainer = document.createElement('div');
     acediff.copyLeftContainer.setAttribute('class', acediff.options.classes.copyLeftContainer);
-
     acediff.options.gutterEl.appendChild(acediff.copyRightContainer);
     acediff.options.gutterEl.appendChild(acediff.copyLeftContainer);
 }
@@ -880,6 +887,7 @@ function getScrollingInfo(acediff, dir)
 
 function getEditorHeight(acediff)
 {
+    console.log(acediff.options);
     return acediff.options.left.element.offsetHeight;
 }
 

--- a/src/brace-diff.js
+++ b/src/brace-diff.js
@@ -137,6 +137,10 @@ extend(AceDiff.prototype, {
         return this.diffs.length;
     },
 
+    getDiffs: function() {
+        return this.diffs;
+    },
+
     // exposes the Ace editors in case the dev needs it
     getEditors: function ()
     {


### PR DESCRIPTION
This resolves 2 issues:

1.  gutterEl being defined on the wrong object in the TSD.
2.  Passing an element instead of an ID would not work and result in several errors.